### PR TITLE
fix(markdown): Adicionado a possibilidade de navegar pelos links do markdown

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,20 +2,26 @@ PODS:
   - Flutter (1.0.0)
   - shared_preferences_ios (0.0.1):
     - Flutter
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
   shared_preferences_ios:
     :path: ".symlinks/plugins/shared_preferences_ios/ios"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
+  url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
 

--- a/lib/src/ui/widgets/markdown.dart
+++ b/lib/src/ui/widgets/markdown.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:markdown/markdown.dart' as md;
 
+import 'package:tabnews/src/utils/open_link.dart';
+
 class MarkedownReader extends StatelessWidget {
   final String body;
   final ScrollController? controller;
@@ -23,16 +25,13 @@ class MarkedownReader extends StatelessWidget {
       controller: controller,
       data: body,
       selectable: true,
+      onTapLink: (text, href, title) async {
+        OpenLink.open(href, context);
+      },
       extensionSet: md.ExtensionSet(
-        md.ExtensionSet.gitHubFlavored.blockSyntaxes,
+        md.ExtensionSet.gitHubWeb.blockSyntaxes,
         [
-          ...md.ExtensionSet.gitHubFlavored.inlineSyntaxes,
-          md.LineBreakSyntax(),
-          md.LinkSyntax(),
-          md.EmojiSyntax(),
-          md.InlineHtmlSyntax(),
-          md.ImageSyntax(),
-          md.AutolinkExtensionSyntax(),
+          ...md.ExtensionSet.gitHubWeb.inlineSyntaxes,
         ],
       ),
     );

--- a/lib/src/utils/open_link.dart
+++ b/lib/src/utils/open_link.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'package:tabnews/src/ui/pages/content.dart';
+import 'package:tabnews/src/utils/navigation.dart';
+
+abstract class OpenLink {
+  static void open(String? href, BuildContext context) {
+    if (href != null) {
+      Uri uri = Uri.parse(href);
+
+      if (_isTabNews(uri) && uri.pathSegments.length > 1) {
+        _launchInApp(uri, context);
+      } else {
+        _launchExternal(uri);
+      }
+    }
+  }
+
+  static bool _isTabNews(Uri uri) {
+    return uri.host == 'www.tabnews.com.br';
+  }
+
+  static void _launchExternal(Uri uri) async {
+    if (await canLaunchUrl(uri)) {
+      launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  static void _launchInApp(Uri uri, BuildContext context) {
+    List<String> segments = uri.pathSegments;
+
+    String username = segments[0];
+    String slug = segments[1];
+
+    Navigation.push(context, ContentPage(username: username, slug: slug));
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import shared_preferences_macos
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -406,6 +406,62 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.7"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.22"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.17"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.13"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   shared_preferences: ^2.0.15
   markdown: ^6.0.1
   markdown_editable_textinput: ^2.1.0
+  url_launcher: ^6.1.7
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
Adicionado funcionalidade de abrir posts do TabNews, dentro do próprio app como seus conteúdos.

Links externos e páginas do TabNews, que ainda não foram implementadas dentro do App, como status e outras, abre no navegador.

Fix: #10 

![CleanShot 2022-11-27 at 16 50 23](https://user-images.githubusercontent.com/5226773/204144428-c3cbbb1c-9f47-4715-9f1c-e1d70bfdff17.gif)
