### PR TITLE
Ambiente de desenvolvimento e produção

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,1 @@
+WEBSERVER_HOST="http://:::3000"

--- a/.env.prod
+++ b/.env.prod
@@ -1,0 +1,1 @@
+WEBSERVER_HOST="https://www.tabnews.com.br"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 
 import 'package:tabnews/src/app.dart';
+import 'package:tabnews/src/enviroment_vars.dart';
 import 'package:tabnews/src/preferences.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await Preferences.init();
+
+  await EnviromentVars.init(useProdEnv: true);
 
   runApp(const App());
 }

--- a/lib/src/enviroment_vars.dart
+++ b/lib/src/enviroment_vars.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class EnviromentVars {
+  static late EnviromentVars _singleton;
+  static EnviromentVars get getVars => _singleton;
+
+  late final String _webserver;
+  String get webserver => _webserver;
+
+  late final bool _debugEnv;
+  bool get debugEnv => _debugEnv;
+
+  static Future init({bool useProdEnv = false}) async {
+    bool devEnviroment = kDebugMode && !useProdEnv;
+    dotenv = DotEnv();
+
+    if (devEnviroment) {
+      await dotenv.load(fileName: ".env.dev");
+    } else {
+      await dotenv.load(fileName: ".env.prod");
+    }
+
+    _singleton = EnviromentVars();
+    _singleton._webserver =
+        dotenv.get("WEBSERVER_HOST", fallback: "www.tabnews.com.br");
+    _singleton._debugEnv = devEnviroment;
+  }
+}

--- a/lib/src/services/auth.dart
+++ b/lib/src/services/auth.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:tabnews/src/enviroment_vars.dart';
 
 import 'package:tabnews/src/services/http_response.dart';
 
 class AuthService {
-  final apiUrl = 'https://www.tabnews.com.br/api/v1';
+  String get apiUrl => '${EnviromentVars.getVars.webserver}/api/v1';
 
   Future<HttpResponse> postLogin(String email, String password) async {
     final response = await http.post(

--- a/lib/src/services/content.dart
+++ b/lib/src/services/content.dart
@@ -1,13 +1,14 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:tabnews/src/enviroment_vars.dart';
 import 'package:tabnews/src/models/comment.dart';
 
 import 'package:tabnews/src/models/content.dart';
 import 'package:tabnews/src/services/http_response.dart';
 
 class ContentService {
-  final apiUrl = 'https://www.tabnews.com.br/api/v1/contents';
+  String get apiUrl => "${EnviromentVars.getVars.webserver}/api/v1/contents";
 
   Future<List<Content>> fetchContents({int page = 1}) async {
     final response = await http.get(Uri.parse('$apiUrl?page=$page'));

--- a/lib/src/services/user.dart
+++ b/lib/src/services/user.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:tabnews/src/enviroment_vars.dart';
 
 import 'package:tabnews/src/models/user.dart';
 
 class UserService {
-  final apiUrl = 'https://www.tabnews.com.br/api/v1';
+  String get apiUrl => '${EnviromentVars.getVars.webserver}/api/v1';
 
   Future<User> fetchUser(String username) async {
     final response = await http.get(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,6 +90,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.2"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   markdown: ^6.0.1
   markdown_editable_textinput: ^2.1.0
   url_launcher: ^6.1.7
+  flutter_dotenv: ^5.0.2
 
 dev_dependencies:
   flutter_test:
@@ -69,7 +70,8 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   assets:
     - lib/assets/
-  #   - images/a_dot_ham.jpeg
+    - .env.dev
+    - .env.prod
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
Opa! O projeto do tabnews.com.br tem um ambiente de desenvolvimento que pode ser iniciado com ```npm run dev```, mas era difícil de acessá-lo pelo aplicativo, já que as URLs das APIs estavam hard-coded, então criei um ```.env.dev``` com a o host de desenvolvimento e o ```.env.prod``` com a variável da API de produção.
As variáveis serão usadas de acordo com a forma de build, sendo o ```.env.dev``` caso esteja sendo executado em debug ou ```.env.prod``` caso esteja sendo usado em release.

## Configurando
Você apenas deve expor a API de desenvolvimento do tabnews modificando a variável ```WEBSERVER_HOST``` do [```.env```](https://github.com/filipedeschamps/tabnews.com.br/blob/main/.env) para "::".
```dosini
# ...
DATABASE_URL=postgres://local_user:local_password@localhost:54320/tabnews
WEBSERVER_HOST=::
WEBSERVER_PORT=3000
# ...
```

## Observações
- No ```.env.dev``` você deve substituir os "::" com o seu endereço de IP, já que o http do Dart não faz.
Exemplo:
```dosini
WEBSERVER_HOST="http://198.168.0.1:3000"
```

- Caso não queira usar as variaveis de produção independente do modo de build:
```dart
await EnviromentVars.init(useProdEnv: true);
```